### PR TITLE
Fix test in GenericsTest.java caused by nondeterministic HashMap iteration and missing MapKey equality

### DIFF
--- a/test/com/esotericsoftware/kryo/serializers/GenericsTest.java
+++ b/test/com/esotericsoftware/kryo/serializers/GenericsTest.java
@@ -449,7 +449,6 @@ class GenericsTest extends KryoTestCase {
 			
 		}
 
-
 		public static class MapKey {
 			public String field1, field2;
 

--- a/test/com/esotericsoftware/kryo/serializers/GenericsTest.java
+++ b/test/com/esotericsoftware/kryo/serializers/GenericsTest.java
@@ -441,12 +441,13 @@ class GenericsTest extends KryoTestCase {
 			List<String> list = new ArrayList<>();
 			for (Set<String> set : other.values.values()) {
 				list_other = new ArrayList<>(set); 
+				list_other.sort(Comparator.naturalOrder());
 			}
 			for (Set<String> set : values.values()) {
 				list = new ArrayList<>(set); 
+				list.sort(Comparator.naturalOrder());
 			}			
 			return Objects.equals(other.values.keySet().toString(), values.keySet().toString()) && Objects.equals(list_other, list);
-			
 		}
 
 		public static class MapKey {

--- a/test/com/esotericsoftware/kryo/serializers/GenericsTest.java
+++ b/test/com/esotericsoftware/kryo/serializers/GenericsTest.java
@@ -436,25 +436,29 @@ class GenericsTest extends KryoTestCase {
 			if (obj == null) return false;
 			if (getClass() != obj.getClass()) return false;
 			ClassWithMap other = (ClassWithMap)obj;
+			return Objects.equals(values, other.values);
+		}
 
-			List<String> list_other = new ArrayList<>();
-			List<String> list = new ArrayList<>();
-			for (Set<String> set : other.values.values()) {
-				list_other = new ArrayList<>(set); 
-				list_other.sort(Comparator.naturalOrder());
-			}
-			for (Set<String> set : values.values()) {
-				list = new ArrayList<>(set); 
-				list.sort(Comparator.naturalOrder());
-			}			
-			return Objects.equals(other.values.keySet().toString(), values.keySet().toString()) && Objects.equals(list_other, list);
+		@Override
+		public int hashCode() {
+			return Objects.hash(values);
 		}
 
 		public static class MapKey {
 			public String field1, field2;
 
-			public String toString () {
-				return field1 + ":" + field2;
+			@Override
+			public boolean equals(Object obj) {
+				if (this == obj) return true;
+				if (!(obj instanceof MapKey)) return false;
+				MapKey other = (MapKey) obj;
+				return Objects.equals(field1, other.field1) &&
+					Objects.equals(field2, other.field2);
+			}
+
+			@Override
+			public int hashCode() {
+				return Objects.hash(field1, field2);
 			}
 		}
 	}

--- a/test/com/esotericsoftware/kryo/serializers/GenericsTest.java
+++ b/test/com/esotericsoftware/kryo/serializers/GenericsTest.java
@@ -436,29 +436,25 @@ class GenericsTest extends KryoTestCase {
 			if (obj == null) return false;
 			if (getClass() != obj.getClass()) return false;
 			ClassWithMap other = (ClassWithMap)obj;
-			return Objects.equals(values, other.values);
+
+			List<String> list_other = new ArrayList<>();
+			List<String> list = new ArrayList<>();
+			for (Set<String> set : other.values.values()) {
+				list_other = new ArrayList<>(set); 
+			}
+			for (Set<String> set : values.values()) {
+				list = new ArrayList<>(set); 
+			}			
+			return Objects.equals(other.values.keySet().toString(), values.keySet().toString()) && Objects.equals(list_other, list);
+			
 		}
 
-		@Override
-		public int hashCode() {
-			return Objects.hash(values);
-		}
 
 		public static class MapKey {
 			public String field1, field2;
 
-			@Override
-			public boolean equals(Object obj) {
-				if (this == obj) return true;
-				if (!(obj instanceof MapKey)) return false;
-				MapKey other = (MapKey) obj;
-				return Objects.equals(field1, other.field1) &&
-					Objects.equals(field2, other.field2);
-			}
-
-			@Override
-			public int hashCode() {
-				return Objects.hash(field1, field2);
+			public String toString () {
+				return field1 + ":" + field2;
 			}
 		}
 	}

--- a/test/com/esotericsoftware/kryo/serializers/GenericsTest.java
+++ b/test/com/esotericsoftware/kryo/serializers/GenericsTest.java
@@ -436,17 +436,29 @@ class GenericsTest extends KryoTestCase {
 			if (obj == null) return false;
 			if (getClass() != obj.getClass()) return false;
 			ClassWithMap other = (ClassWithMap)obj;
-			if (values == null) {
-				if (other.values != null) return false;
-			} else if (!values.toString().equals(other.values.toString())) return false;
-			return true;
+			return Objects.equals(values, other.values);
+		}
+
+		@Override
+		public int hashCode() {
+			return Objects.hash(values);
 		}
 
 		public static class MapKey {
 			public String field1, field2;
 
-			public String toString () {
-				return field1 + ":" + field2;
+			@Override
+			public boolean equals(Object obj) {
+				if (this == obj) return true;
+				if (!(obj instanceof MapKey)) return false;
+				MapKey other = (MapKey) obj;
+				return Objects.equals(field1, other.field1) &&
+					Objects.equals(field2, other.field2);
+			}
+
+			@Override
+			public int hashCode() {
+				return Objects.hash(field1, field2);
 			}
 		}
 	}


### PR DESCRIPTION
I noticed failures occur when using nondex to run
```mvn -pl main-versioned edu.illinois:nondex-maven-plugin:2.1.7:nondex -Dtest=com.esotericsoftware.kryo.serializers.GenericsTest#testMapTypeParams```

**Reasons for the failures:**

1. Nondeterministic HashMap iteration order: even if two maps contain the same entries, their toString() representations can differ, causing the test comparison to fail.
2. MapKey does not define how keys should be compared: map keys are compared by reference rather than value, so structurally identical maps may appear unequal.

**How I Fix:**
Use a deterministic comparison of map entries and ensured that keys are compared structurally rather than by reference.